### PR TITLE
Fix references from original source

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Hcaptcha provides the `verify/2` method. Below is an example using a Phoenix con
 
 ```elixir
   def create(conn, params) do
-    case Hcaptcha.verify(params["h-aptcha-response"]) do
+    case Hcaptcha.verify(params["h-captcha-response"]) do
       {:ok, response} -> do_something
       {:error, errors} -> handle_error
     end

--- a/lib/hcaptcha.ex
+++ b/lib/hcaptcha.ex
@@ -1,9 +1,8 @@
 defmodule Hcaptcha do
   @moduledoc """
-    A module for verifying hCAPTCHA version 2.0 response strings.
+    A module for verifying hCAPTCHA version 1 response strings.
 
-    See the [documentation](https://developers.google.com/hcaptcha/docs/verify)
-    for more details.
+    See the [documentation](https://docs.hcaptcha.com/) for more details.
   """
 
   alias Hcaptcha.{Config, Http, Response}

--- a/lib/hcaptcha.ex
+++ b/lib/hcaptcha.ex
@@ -63,7 +63,7 @@ defmodule Hcaptcha do
 
   defp atomise_api_error(error) do
     # See why we are using `to_atom` here:
-    # https://github.com/samueljseay/hcaptcha/pull/28#issuecomment-313604733
+    # https://github.com/samueljseay/recaptcha/pull/28#issuecomment-313604733
     error
     |> String.replace("-", "_")
     |> String.to_atom()


### PR DESCRIPTION
It feels like these were in the original source and were broken by the find & replace used to move from recaptcha to hcaptcha.

I also think that the 'noscript' section in the template could possibly be removed unless it is valid for the hcaptcha service too? It seems to reference google.com so I assume it isn't currently valid. Referencing to: https://github.com/Sebi55/hcaptcha/blob/abf4557fe6d5456bb1283d80b658a840a12e130b/lib/template.html.eex#L43-L67

Thank you for creating this project! I've got some bot/spam sign ups on a side project of mine and I'm very happy that you have put this together. 