### PR TITLE
Upgrade to new hcaptcha URL address

### DIFF
--- a/lib/template.html.eex
+++ b/lib/template.html.eex
@@ -1,4 +1,4 @@
-<script src="https://www.hCaptcha.com/1/api.js?<%= @options[:onload] %>hl=<%= @options[:hl] %>" async defer></script>
+<script src="https://js.hcaptcha.com/1/api.js?<%= @options[:onload] %>hl=<%= @options[:hl] %>" async defer></script>
 
 <%= if @options[:size] == "invisible" do %>
 <script type="text/javascript">


### PR DESCRIPTION
I found a warning in the console about upgrading to the new JS hCaptcha URL.